### PR TITLE
Please Add King Edward VI Grammar School (KEGS)

### DIFF
--- a/lib/domains/uk/org/kegs.txt
+++ b/lib/domains/uk/org/kegs.txt
@@ -1,0 +1,2 @@
+King Edward VI Grammar School
+King Edward VI Grammar School


### PR DESCRIPTION

[kegs.txt](https://github.com/rudrrayan/swot/files/3512499/kegs.txt)
this is a secondary school in the UK that reaches sixth form. It is located in Chelmsford.